### PR TITLE
Fix version check in command line

### DIFF
--- a/safepass/__main__.py
+++ b/safepass/__main__.py
@@ -1,5 +1,6 @@
 import safepass
 import sys
+import pkg_resources
 from getpass import getpass
 
 
@@ -9,12 +10,12 @@ def is_safe(passwd):
     return safe
 
 
+
 def main():
     if len(sys.argv) > 1:
         if '--version' in sys.argv:
-            sys.path.insert(0, '..')
-            from setup import VERSION
-            print(VERSION)
+            version = pkg_resources.require("safepass")[0].version
+            print(version)
             result = 0
         else:
             result = True


### PR DESCRIPTION
Hi, the tool is very handy! 

I came across a small hitch when requesting the version after installing it with `pip install`.

```
user:safepass$ safepass --version
Traceback (most recent call last):
  File "/home/user/.pyenv/versions/testing/bin/safepass", line 10, in <module>
    sys.exit(main())
  File "/home/user/.pyenv/versions/3.6.5/envs/testing/lib/python3.6/site-packages/safepass/__main__.py", line 16, in main
    from setup import VERSION
ModuleNotFoundError: No module named 'setup'
```

This is good enough to handle the `--version` parameter correctly but I could also use `argparse` and provide help and a bit more robustness if you prefer.

Regards,
Alex


